### PR TITLE
fix: change cache-control header order

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ When running in production, these headers will be included by `og_edge`:
 
 ```jsx
 'content-type': 'image/png',
-'cache-control': 'public, immutable, no-transform, max-age=31536000',
+'cache-control': 'public, max-age=31536000, no-transform, immutable',
 ```
 
 During development, the `cache-control: no-cache, no-store` header is used

--- a/mod.ts
+++ b/mod.ts
@@ -227,7 +227,7 @@ export class ImageResponse {
         "content-type": "image/png",
         "cache-control": isDev
           ? "no-cache, no-store"
-          : "public, immutable, no-transform, max-age=31536000",
+          : "public, max-age=31536000, no-transform, immutable",
         ...extendedOptions.headers,
       },
       status: extendedOptions.status,


### PR DESCRIPTION
it looks like Chrome doesn't support `immutable` so having `max-age` before `immutable` to make sure `max-age` is applied. https://bugs.chromium.org/p/chromium/issues/detail?id=611416#c46