### PR TITLE
fix: fix types via inheritance.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "deno.enable": true,
   "deno.unstable": true,
+  "deno.lint": true,
   "deno.importMap": ".netlify/edge-functions-import-map.json",
   "editor.defaultFormatter": "denoland.vscode-deno"
 }

--- a/mod.ts
+++ b/mod.ts
@@ -176,7 +176,7 @@ const loadDynamicAsset = ({ emoji }: { emoji?: EmojiType }) => {
   };
 };
 
-export class ImageResponse {
+export class ImageResponse extends Response {
   constructor(element: ReactElement, options: ImageResponseOptions = {}) {
     const extendedOptions = Object.assign(
       {
@@ -222,7 +222,7 @@ export class ImageResponse {
       },
     });
 
-    return new Response(result, {
+    super(result, {
       headers: {
         "content-type": "image/png",
         "cache-control": isDev


### PR DESCRIPTION
I think this should fix the typing of `ImageResponse` by having it extend `Response`. Can you validate on your end?

<img width="829" alt="image" src="https://user-images.githubusercontent.com/5748289/203246872-abf119ac-0b9d-4f57-ada0-b440f2eeb478.png">
